### PR TITLE
Configure GitHub Pages deployment

### DIFF
--- a/.github/workflows/pages.yml
+++ b/.github/workflows/pages.yml
@@ -1,0 +1,30 @@
+name: Deploy static site to Pages
+
+on:
+  push:
+    branches: ["main"]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  pages: write
+  id-token: write
+
+concurrency:
+  group: "pages"
+  cancel-in-progress: true
+
+jobs:
+  deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v3
+      - uses: actions/configure-pages@v2
+      - uses: actions/upload-pages-artifact@v1
+        with:
+          path: '.'
+      - id: deployment
+        uses: actions/deploy-pages@v1

--- a/README.md
+++ b/README.md
@@ -1,1 +1,13 @@
 # ittijoseph.github.io
+
+This repository contains the source code for my personal website.
+The site is automatically deployed using [GitHub Pages](https://pages.github.com).
+
+## Local development
+
+Open `index.html` in your browser to preview the site locally.
+
+## Deployment
+
+Push changes to the `main` branch. The included GitHub Actions workflow builds and deploys the site to GitHub Pages.
+


### PR DESCRIPTION
## Summary
- add GitHub Actions workflow to deploy site to GitHub Pages
- document local development and deployment steps
- add `.nojekyll` to bypass Jekyll processing

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_689c8181dd68832dac7ceffcc40d1a03